### PR TITLE
refactor: Main menu application exit set running to false. 

### DIFF
--- a/Simple Banking System (Java)/task/src/banking/menu/main/MainMenuApplication.java
+++ b/Simple Banking System (Java)/task/src/banking/menu/main/MainMenuApplication.java
@@ -33,7 +33,7 @@ public class MainMenuApplication {
                 case CREATE_ACCOUNT -> handleCreateAccount();
                 case LOGIN -> handleLogin();
                 case EXIT -> {
-                    System.exit(0);
+                    running = false;
                 }
                 default -> System.out.println("Invalid option. Try Again.");
             }

--- a/Simple Banking System (Java)/task/test/AllTests.java
+++ b/Simple Banking System (Java)/task/test/AllTests.java
@@ -1,4 +1,3 @@
-import banking.database.DatabaseManagerTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -7,7 +6,6 @@ import org.junit.runners.Suite;
         // Account
         banking.account.AccountControllerTest.class,
         banking.account.AccountTest.class,
-        banking.account.AccountStoreTest.class,
 
         // Card
         banking.card.CardNumberGeneratorTest.class,
@@ -20,7 +18,8 @@ import org.junit.runners.Suite;
         // Login
         banking.login.LoginManagerTest.class,
         banking.login.LoginServiceTest.class,
-        
+
+        // TODO: Replace System.exit() in MainMenuApplication with injectable ExitHandler for test-safe exit.
         // Menu Login
         banking.menu.login.LoginMenuApplicationTest.class,
         banking.menu.login.LoginMenuResultTest.class,


### PR DESCRIPTION
The start() method in the Main Menu Application class has the exit option change to running = false instead of System.exit(0)